### PR TITLE
fixed panic on windows, log folder assignement

### DIFF
--- a/api.go
+++ b/api.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"runtime"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -25,6 +26,10 @@ var (
 func init() {
 	// Initialize the logging component by default
 	logrus.SetLevel(logrus.DebugLevel)
+	if runtime.GOOS == "windows" {
+		SetLoggerDirectory("tmp")
+		return
+	}
 	SetLoggerDirectory("/tmp")
 }
 


### PR DESCRIPTION
I had a bug running the client on windows (w10)
It wasn't able to open the folder for the log because of the format
added a check, if windows, don't use "/"