### PR TITLE
optimize subscription logic

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,3 +5,5 @@ require (
 	github.com/pkg/errors v0.8.1
 	github.com/sirupsen/logrus v1.4.1
 )
+
+go 1.13

--- a/go.mod
+++ b/go.mod
@@ -5,5 +5,3 @@ require (
 	github.com/pkg/errors v0.8.1
 	github.com/sirupsen/logrus v1.4.1
 )
-
-go 1.13

--- a/websocket.go
+++ b/websocket.go
@@ -186,7 +186,7 @@ func (wc *WebSocketClient) Connect() (<-chan *WebSocketDownstreamMessage, <-chan
 	websocket.DefaultDialer.TLSClientConfig = &tls.Config{InsecureSkipVerify: wc.skipVerifyTls}
 
 	// Connect ws server
-	websocket.DefaultDialer.ReadBufferSize = 102400 //100 kb
+	websocket.DefaultDialer.ReadBufferSize = 2048000 //2000 kb
 	wc.conn, _, err = websocket.DefaultDialer.Dial(u, nil)
 	if err != nil {
 		return wc.messages, wc.errors, err

--- a/websocket.go
+++ b/websocket.go
@@ -314,6 +314,8 @@ func (wc *WebSocketClient) Subscribe(channels ...*WebSocketSubscribeMessage) err
 			if id != c.Id {
 				return errors.Errorf("Invalid ack id %s, expect %s", id, c.Id)
 			}
+		case err := <-wc.errors:
+			return errors.Errorf("subscribe error, %s", err.Error())
 		case <-time.After(time.Second * 5):
 			return errors.Errorf("Wait ack message timeout in %d s", 5)
 		}


### PR DESCRIPTION
return error when subscribing to a topic which does not exist, so we can handle subscription error, not "Wait ack message timeout" after 5 seconds.