### PR TITLE
Add Override Requester Support

### DIFF
--- a/api.go
+++ b/api.go
@@ -100,6 +100,13 @@ func ApiSkipVerifyTlsOption(skipVerifyTls bool) ApiServiceOption {
 	}
 }
 
+// ApiRequesterOption creates a instance of ApiServiceOption about requester.
+func ApiRequesterOption(requester Requester) ApiServiceOption {
+	return func(service *ApiService) {
+		service.requester = requester
+	}
+}
+
 // NewApiService creates a instance of ApiService by passing ApiServiceOptions, then you can call methods.
 func NewApiService(opts ...ApiServiceOption) *ApiService {
 	as := &ApiService{requester: &BasicRequester{}}

--- a/http.go
+++ b/http.go
@@ -177,6 +177,19 @@ type Response struct {
 	body []byte
 }
 
+// Creates a new Response
+func NewResponse(
+	request *Request,
+	response *http.Response,
+	body []byte,
+) *Response {
+	return &Response{
+		request:  request,
+		response: response,
+		body:     body,
+	}
+}
+
 // ReadBody read the response data, then return it.
 func (r *Response) ReadBody() ([]byte, error) {
 	if r.body != nil {

--- a/http.go
+++ b/http.go
@@ -163,11 +163,11 @@ func (br *BasicRequester) Request(request *Request, timeout time.Duration) (*Res
 		logrus.Debugf("Received a HTTP response#%d: %s", rid, string(dump))
 	}
 
-	return &Response{
-		request:  request,
-		Response: rsp,
-		body:     nil,
-	}, nil
+	return NewResponse(
+		request,
+		rsp,
+		nil,
+	), nil
 }
 
 // A Response represents a HTTP response.
@@ -177,7 +177,7 @@ type Response struct {
 	body []byte
 }
 
-// Creates a new Response
+// NewResponse Creates a new Response
 func NewResponse(
 	request *Request,
 	response *http.Response,

--- a/http.go
+++ b/http.go
@@ -185,7 +185,7 @@ func NewResponse(
 ) *Response {
 	return &Response{
 		request:  request,
-		response: response,
+		Response: response,
 		body:     body,
 	}
 }


### PR DESCRIPTION
Add support to api service support to add a custom requester during definition. Since `Requester` is already an interface this can allow users to create a custom requester as desired.