### PR TITLE
adds missing ticker fields

### DIFF
--- a/symbol.go
+++ b/symbol.go
@@ -56,17 +56,22 @@ func (as *ApiService) TickerLevel1(symbol string) (*ApiResponse, error) {
 
 // A TickerModel represents a market ticker for all trading pairs in the market (including 24h volume).
 type TickerModel struct {
-	Symbol      string `json:"symbol"`
-	SymbolName  string `json:"symbolName"`
-	Buy         string `json:"buy"`
-	Sell        string `json:"sell"`
-	ChangeRate  string `json:"changeRate"`
-	ChangePrice string `json:"changePrice"`
-	High        string `json:"high"`
-	Low         string `json:"low"`
-	Vol         string `json:"vol"`
-	VolValue    string `json:"volValue"`
-	Last        string `json:"last"`
+	Symbol           string `json:"symbol"`
+	SymbolName       string `json:"symbolName"`
+	Buy              string `json:"buy"`
+	Sell             string `json:"sell"`
+	ChangeRate       string `json:"changeRate"`
+	ChangePrice      string `json:"changePrice"`
+	High             string `json:"high"`
+	Low              string `json:"low"`
+	Vol              string `json:"vol"`
+	VolValue         string `json:"volValue"`
+	Last             string `json:"last"`
+	AveragePrice     string `json:"averagePrice"`
+	TakerFeeRate     string `json:"takerFeeRate"`
+	MakerFeeRate     string `json:"makerFeeRate"`
+	TakerCoefficient string `json:"takerCoefficient"`
+	MakerCoefficient string `json:"makerCoefficient"`
 }
 
 // A TickersModel is the set of *MarketTickerModel.


### PR DESCRIPTION
The following fields are missing:

```
AveragePrice     string `json:"averagePrice"`
TakerFeeRate     string `json:"takerFeeRate"`
MakerFeeRate     string `json:"makerFeeRate"`
TakerCoefficient string `json:"takerCoefficient"`
MakerCoefficient string `json:"makerCoefficient"`
```