### PR TITLE
change cancelAfter type

### DIFF
--- a/order.go
+++ b/order.go
@@ -113,7 +113,7 @@ type OrderModel struct {
 	Hidden        bool   `json:"hidden"`
 	IceBerg       bool   `json:"iceberg"`
 	VisibleSize   string `json:"visibleSize"`
-	CancelAfter   uint64 `json:"cancelAfter"`
+	CancelAfter   int64  `json:"cancelAfter"`
 	Channel       string `json:"channel"`
 	ClientOid     string `json:"clientOid"`
 	Remark        string `json:"remark"`


### PR DESCRIPTION
Hi ,
When receiving the orders list, sometimes the value of cancelAfter is -1 and it causes an error in the system .
error message :
`[] json: cannot unmarshal number -1 into Go struct field OrderModel.cancelAfter of type uint64`