### PR TITLE
Clone DefaultTransport before modifying it to avoid DATA RACE

### DIFF
--- a/http.go
+++ b/http.go
@@ -135,7 +135,7 @@ func (br *BasicRequester) Request(request *Request, timeout time.Duration) (*Res
 		tr.TLSClientConfig.InsecureSkipVerify = request.SkipVerifyTls
 	}
 
-	cli := http.DefaultClient
+	cli := http.Client{}
 	cli.Transport, cli.Timeout = tr, timeout
 
 	req, err := request.HttpRequest()

--- a/http.go
+++ b/http.go
@@ -128,12 +128,11 @@ type BasicRequester struct {
 
 // Request makes a http request.
 func (br *BasicRequester) Request(request *Request, timeout time.Duration) (*Response, error) {
-	tr := http.DefaultTransport
-	tc := tr.(*http.Transport).TLSClientConfig
-	if tc == nil {
-		tc = &tls.Config{InsecureSkipVerify: request.SkipVerifyTls}
+	tr := http.DefaultTransport.(*http.Transport).Clone()
+	if tr.TLSClientConfig == nil {
+		tr.TLSClientConfig = &tls.Config{InsecureSkipVerify: request.SkipVerifyTls}
 	} else {
-		tc.InsecureSkipVerify = request.SkipVerifyTls
+		tr.TLSClientConfig.InsecureSkipVerify = request.SkipVerifyTls
 	}
 
 	cli := http.DefaultClient


### PR DESCRIPTION
- In a large program, `http.DefaultTransport` is used by other packages/modules, it's not correct to modify its fields because that causes DATA RACE. So this PR clones it before making any modification. Fortunately, there is a `.clone()` function to make the clone! 
- Likewise, this also avoids using the `http.DefaultClient` and modifying it. Again a bad idea!  Instead, the PR creates a new instance. 